### PR TITLE
[issue:37] Fix preferences window not showing

### DIFF
--- a/Goose/Goose/GooseApp.swift
+++ b/Goose/Goose/GooseApp.swift
@@ -147,6 +147,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             name: Notification.Name("ShowAboutWindow"),
             object: nil
         )
+        
+        // Register notification handler for showing preferences window
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(showPreferencesWindow),
+            name: Notification.Name("ShowPreferencesWindow"),
+            object: nil
+        )
     }
     
     func applicationWillTerminate(_ notification: Notification) {
@@ -180,6 +188,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         if let url = URL(string: "goose://about") {
             NSWorkspace.shared.open(url)
+        }
+    }
+    
+    @objc private func showPreferencesWindow() {
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        
+        // Open the Settings window using the standard macOS preferences shortcut
+        if #available(macOS 13, *) {
+            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        } else {
+            NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
         }
     }
     

--- a/Goose/Goose/Services/MenuBarManager.swift
+++ b/Goose/Goose/Services/MenuBarManager.swift
@@ -170,7 +170,8 @@ class MenuBarManager: NSObject, ObservableObject {
     }
     
     @objc private func showPreferences() {
-        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        // Use NotificationCenter to trigger preferences window, similar to About window
+        NotificationCenter.default.post(name: Notification.Name("ShowPreferencesWindow"), object: nil)
     }
     
     @objc private func showAbout() {


### PR DESCRIPTION
Fixes #37: Make preferences window accessible

### Problem
The preferences window was implemented but never appeared when selected from the menu due to incorrect window triggering method.

### Solution
- Changed MenuBarManager.showPreferences() to use NotificationCenter pattern (similar to About window)
- Added ShowPreferencesWindow notification handler in AppDelegate
- Handler properly triggers the Settings scene using standard macOS API
- Maintains compatibility with both macOS 13+ (showSettingsWindow) and older versions

### Testing
- Verified preferences window opens from menu bar
- Tested keyboard shortcut (Cmd+,)
- Confirmed all preference tabs display correctly
- Verified window can be closed and reopened

This implementation follows the established pattern used by the About window, using NotificationCenter for communication between the menu bar manager and the app delegate.
<details><summary>Goose evaluator</summary>
<p>
goose:swarm:evaluator:bright-0912-moth</p>
</details>